### PR TITLE
Improve dtype handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and [Element](https://github.com/vector-im/element-android)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Bugfix 🐛:
+- Fixing floating-point error for `np.float16, np.float32` in `Similarity().fit()`, see#9
+
+### Other changes:
+- Use deprecated decorator for `UMAPSimilarity`
+- Refactor all type definitions
+- Ensure using the same MODES, METRICS, and NORMS  in the cli and the package itself
 
 
 ## [0.3.0] - 2022-07-22

--- a/extra-requirements.txt
+++ b/extra-requirements.txt
@@ -6,3 +6,4 @@ pytest-cov:            testing
 pytest-rerunfailures:  testing
 pdoc3:                 docs
 umap-learn:            docs, testing, umap
+decorit:               docs, testing, umap

--- a/flake8-CI.cfg
+++ b/flake8-CI.cfg
@@ -7,6 +7,6 @@ count = True
 # exclude some errors
 ignore = S101, C101, N, DAR401, DAR402, W504, WPS306, WPS352
 per-file-ignores =
-    src/cfs/__init__.py:F401, F403, D104, D400
+    src/mosaic/__init__.py:F401, F403, D104, D400, E402
     setup.py:D100
     test/*.py:WPS, DAR101, DAR201

--- a/src/mosaic/__init__.py
+++ b/src/mosaic/__init__.py
@@ -2,6 +2,10 @@
 """.. include:: ../../README.md"""
 __all__ = ['Clustering', 'GridSearchCV', 'Similarity', 'UMAPSimilarity']
 
+METRICS = {'correlation', 'NMI', 'JSD', 'GY'}
+MODES = {'CPM', 'modularity', 'linkage', 'kmedoids'}
+NORMS = {'joint', 'geometric', 'arithmetic', 'min', 'max'}
+
 import mosaic.utils  # noqa: F401
 from .clustering import Clustering
 from .gridsearch import GridSearchCV

--- a/src/mosaic/__main__.py
+++ b/src/mosaic/__main__.py
@@ -17,9 +17,6 @@ from mosaic.utils import save_clusters, savetxt
 # setup matplotlibs rcParam
 pplt.use_style(figsize=2, figratio=1, cmap='turbo')
 
-NORMALIZES = ['joint', 'geometric', 'arithmetic', 'min', 'max']
-METRICS = ['correlation', 'NMI', 'JSD', 'GY']
-MODES = ['CPM', 'modularity', 'linkage', 'kmedoids']
 PRECISION = ['half', 'single', 'double']
 PRECISION_TO_DTYPE = {
     'half': np.float16,
@@ -50,12 +47,12 @@ def main():
     '--metric',
     default='correlation',
     show_default=True,
-    type=click.Choice(METRICS, case_sensitive=True),
+    type=click.Choice(mosaic.METRICS, case_sensitive=True),
     help='Metric used to estimate similarity measure matrix.',
 )
 @click.option(
     '--normalize-method',
-    type=click.Choice(NORMALIZES, case_sensitive=True),
+    type=click.Choice(mosaic.NORMS, case_sensitive=True),
     help=(
         'Only required for metric="NMI". Determines the normalization factor '
         'for the mutual information. See docs for help.'
@@ -174,7 +171,7 @@ def similarity(
     '--mode',
     default='CPM',
     show_default=True,
-    type=click.Choice(MODES, case_sensitive=True),
+    type=click.Choice(mosaic.MODES, case_sensitive=True),
     help='Mode used for Leiden clustering.',
 )
 @click.option(

--- a/src/mosaic/_correlation_utils.py
+++ b/src/mosaic/_correlation_utils.py
@@ -89,12 +89,16 @@ def _estimate_densities(
 
 @beartype
 def _correlation(X: Float2DArray) -> FloatMatrix:
-    """Return the correlation of input.
+    """Return the Pearson correlation coefficient of input.
 
-    Each feature (column) of X need to be mean-free with standard deviation 1.
+    In general, the result matrix is hermitian with diagonal elements equal
+    1. Due to floating point rounding this is not guaranteed by
+    [np.corrcoef](https://github.com/numpy/numpy/blob/54c52f13713f3d21795926ca4dbb27e16fada171/numpy/lib/function_base.py#L2766-L2770)
+    and therefore it is enforced in this function.
 
     """
-    corr = X.T / len(X) @ X
+    # numpy.corrcoef clips result to [-1, 1]
+    corr = np.corrcoef(X, rowvar=False)
 
     # check if matrix is symmetric with diag(C)=1 within dtype precision
     atol = np.max([
@@ -116,9 +120,7 @@ def _correlation(X: Float2DArray) -> FloatMatrix:
     # symmetrize and enforce diag equals 1
     corr = 0.5 * (corr + corr.T)
     corr[np.diag_indices_from(corr)] = 1
-    # clip result. Due to numerical artifacts, for too little samples the
-    # correlation can become larger one.
-    return np.clip(corr, a_min=-1, a_max=1)
+    return corr
 
 
 @beartype

--- a/src/mosaic/_typing.py
+++ b/src/mosaic/_typing.py
@@ -12,15 +12,12 @@ All rights reserved.
 import numpy as np
 from beartype.typing import List, Union
 from beartype.vale import Is, IsAttr, IsEqual
+from mosaic import METRICS, MODES, NORMS
 
 try:  # for python <= 3.8 use typing_extensions
     from beartype.typing import Annotated
 except ImportError:
     from typing_extensions import Annotated
-
-METRICS = {'correlation', 'NMI', 'JSD', 'GY'}
-MODES = {'CPM', 'modularity', 'linkage', 'kmedoids'}
-NORMS = {'joint', 'geometric', 'arithmetic', 'min', 'max'}
 
 
 def _get_resolution(x):

--- a/src/mosaic/umap_similarity.py
+++ b/src/mosaic/umap_similarity.py
@@ -13,6 +13,7 @@ import warnings
 import numpy as np
 from beartype import beartype
 from beartype.typing import Optional
+from decorit import deprecated
 
 from mosaic._typing import (  # noqa:WPS436
     ArrayLikeFloat,
@@ -68,6 +69,16 @@ class UMAPSimilarity:  # noqa: WPS214
 
     _default_n_components: PositiveInt = 2
 
+    @deprecated(
+        (
+            'UMAPSimilarity class will be removed. As shown in our '
+            'publication, using Leiden/CPM outpferms an additional '
+            'UMAP embedding. If an embedding is desired, using MDS '
+            'in high dimensions is preferable.'
+        ),
+        since='0.2.1',
+        remove='1.0.0',
+    )
     @beartype
     def __init__(
         self,

--- a/tests/test__correlation.py
+++ b/tests/test__correlation.py
@@ -11,6 +11,7 @@ import os.path
 import numpy as np
 import pytest
 from beartype.roar import BeartypeException
+from sklearn.preprocessing import StandardScaler
 
 import mosaic
 
@@ -131,3 +132,26 @@ def test__correlation(X, result, error):
     else:
         with pytest.raises(error):
             mosaic._correlation_utils._correlation(X)
+
+
+@pytest.mark.parametrize('n_samples, n_features, dtype', [
+    (100000, 10, np.float16),
+    (100000, 10, np.float32),
+    (100000, 10, np.float64),
+    (10000, 100, np.float16),
+    (10000, 100, np.float32),
+    (1000, 1000, np.float16),
+    (1000, 1000, np.float32),
+])
+def test__correlation_dtype(n_samples, n_features, dtype):
+    np.random.seed(42)
+
+    # create random data
+    X = StandardScaler().fit_transform(
+        np.random.normal(
+            size=(n_samples, n_features),
+        ).astype(dtype),
+    )
+
+    # check if results is symmetric and diagonal close to 1
+    mosaic._correlation_utils._correlation(X)


### PR DESCRIPTION
- Fixing #9  by f1c565326128c53ace723f418d6fa167b9367c6f
- Use deprecated decorator for `UMAPSimilarity`
- Refactor all type definitions
- Ensure using the same MODES, METRICS, and NORMS  in the cli and the package itself